### PR TITLE
Install Or Update Dependabot to support Docker and Gomods

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: daily
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: daily


### PR DESCRIPTION

Enable Dependabot for Docker and GoMod if not already so.
Keeping K8s dependencies up-to-date. 

This PR is created by bot.

Signed-off-by: zhuxiaow@google.com
